### PR TITLE
Prevent warning when all correlations are significant

### DIFF
--- a/R/omixerRand.R
+++ b/R/omixerRand.R
@@ -199,13 +199,17 @@ omixerRand <- function(df, sampleId="sampleId", block="block", iterNum=1000,
     })
     corSum <- bind_rows(corSumList)
 
-    #Find the optimal layout
-    chosenLayout <- (corSum %>% filter(pTest == FALSE) %>%
-        filter(absSum == min(absSum)))$layoutNum[1]
-
+    ## Find the optimal layout
+    if (all(corSum$pTest)) {
+        warning("All randomized layouts contained unwanted correlations.")
+        chosenLayout <- NA
+    } else {
+    chosenLayout <- (corSum %>% filter(pTest == FALSE) %>% filter(absSum == 
+                                                                    min(absSum)))$layoutNum[1]
+    }
+    
     ## Check number of optimized layouts
     if(is.na(chosenLayout)) {
-        warning("All randomized layouts contained unwanted correlations.")
         warning("Returning best possible layout.")
         nonoptLayout <- (corSum %>% filter(absSum == min(absSum)))$layoutNum[1]
     }


### PR DESCRIPTION
In the case were all corSum$pTest values are TRUE, min(absSum) will produce the warning "no non-missing arguments to min; returning Inf" because there are 0 rows left in the corSum object after filtering. An additional test was added here to prevent that warning.